### PR TITLE
CSS3 to make sure background image is fullscreen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -22,9 +22,11 @@ h3 {
 }
 
 #map {
-    background-image: url(bm.jpg);
-    background-repeat: no-repeat;
-    background-size: 100%;
+    background: url(bm.jpg) no-repeat center center fixed;
+    -webkit-background-size: cover;
+    -moz-background-size: cover;
+    -o-background-size: cover;
+    background-size: cover;
 }
 
 #map, #c, #c-glow, #o {


### PR DESCRIPTION
Requires IE9+, but already seems to be a requirement.
